### PR TITLE
Update files to allow current vyos builds to be carried out

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add this to your vyos-modular config
 modules:
   - type: git
     url: https://github.com/jack-broadway/vyos-module-tailscale.git
-    version: main
+    version: current
 ```  
 
 For ami, crux and equuleus builds, use `version: main`  

--- a/README.md
+++ b/README.md
@@ -11,4 +11,8 @@ modules:
   - type: git
     url: https://github.com/jack-broadway/vyos-module-tailscale.git
     version: main
-```
+```  
+
+For ami, crux and equuleus builds, use `version: main`  
+
+For current builds, use `version: current`

--- a/module.yaml
+++ b/module.yaml
@@ -1,7 +1,7 @@
 name: tailscale
 version: 1.0.0
 repositories:
-  - apt_entry: "deb https://pkgs.tailscale.com/stable/debian buster main" 
+  - apt_entry: "deb https://pkgs.tailscale.com/stable/debian bullseye main" 
     gpg_key: "tailscale.gpg"
 packages:
   - tailscale

--- a/vyos-core/patches/ifconfig-init-add-tailscale.patch
+++ b/vyos-core/patches/ifconfig-init-add-tailscale.patch
@@ -16,8 +16,8 @@ index 281d25e..ec6e832 100755
  
  
  # interfaces = Sections.reserved()
--interfaces = ['eno', 'ens', 'enp', 'enx', 'eth', 'vmnet', 'lo', 'tun', 'wan', 'pppoe', 'pppoa', 'adsl']
-+interfaces = ['eno', 'ens', 'enp', 'enx', 'eth', 'vmnet', 'lo', 'tun', 'wan', 'pppoe', 'pppoa', 'adsl', 'tailscale']
+-interfaces = ['eno', 'ens', 'enp', 'enx', 'eth', 'vmnet', 'lo', 'tun', 'wan', 'pppoe']
++interfaces = ['eno', 'ens', 'enp', 'enx', 'eth', 'vmnet', 'lo', 'tun', 'wan', 'pppoe', 'tailscale']
  glob_ifnames = '/sys/class/net/({})*'.format('|'.join(interfaces))
  
  


### PR DESCRIPTION
* Changed tailscale version to bullseye
* Updated patches applied in vyos-core

As mentioned in my [PR for vyos-modular](https://github.com/jack-broadway/vyos-modular/pull/1), instead of merging these changes to `main`, a new feature branch should be created for current builds and these changes should be merged there.